### PR TITLE
Improve CallbackDispatcher creation with functional options

### DIFF
--- a/callback-dispatcher.go
+++ b/callback-dispatcher.go
@@ -31,7 +31,7 @@ func MessageHandler(handler MessageEntryHandler) HandlerSetter {
 }
 
 // DeliveryHandler sets CallbackDispatcher's deliveryHandler to handler
-func d(handler MessageEntryHandler) HandlerSetter {
+func DeliveryHandler(handler MessageEntryHandler) HandlerSetter {
 	return func(dispatcher *CallbackDispatcher) {
 		dispatcher.deliveryHandler = handler
 	}

--- a/callback-dispatcher.go
+++ b/callback-dispatcher.go
@@ -3,45 +3,99 @@ package fbmessenger
 // MessageEntryHandler functions are for handling individual interactions with a user.
 type MessageEntryHandler func(cb *MessagingEntry) error
 
+func nullHandler(e *MessagingEntry) error {
+	return nil
+}
+
 /*
 CallbackDispatcher routes each MessagingEntry included in a callback to an appropriate
 handler for the type of entry. Note that due to webhook batching, a handler may be called
 more than once per callback.
 */
 type CallbackDispatcher struct {
-	MessageHandler        MessageEntryHandler
-	DeliveryHandler       MessageEntryHandler
-	PostbackHandler       MessageEntryHandler
-	AuthenticationHandler MessageEntryHandler
-	ReferralHandler       MessageEntryHandler
+	messageHandler        MessageEntryHandler
+	deliveryHandler       MessageEntryHandler
+	postbackHandler       MessageEntryHandler
+	authenticationHandler MessageEntryHandler
+	referralHandler       MessageEntryHandler
+}
+
+// HandlerSetter implements functional options for setting up CallbackDispatcher
+type HandlerSetter func(*CallbackDispatcher)
+
+// MessageHandler sets CallbackDispatcher's messageHandler to handler
+func MessageHandler(handler MessageEntryHandler) HandlerSetter {
+	return func(dispatcher *CallbackDispatcher) {
+		dispatcher.messageHandler = handler
+	}
+}
+
+// DeliveryHandler sets CallbackDispatcher's deliveryHandler to handler
+func d(handler MessageEntryHandler) HandlerSetter {
+	return func(dispatcher *CallbackDispatcher) {
+		dispatcher.deliveryHandler = handler
+	}
+}
+
+// PostbackHandler sets CallbackDispatcher's postbackHandler to handler
+func PostbackHandler(handler MessageEntryHandler) HandlerSetter {
+	return func(dispatcher *CallbackDispatcher) {
+		dispatcher.postbackHandler = handler
+	}
+}
+
+// AuthenticationHandler sets CallbackDispatcher's authenticationHandler to handler
+func AuthenticationHandler(handler MessageEntryHandler) HandlerSetter {
+	return func(dispatcher *CallbackDispatcher) {
+		dispatcher.authenticationHandler = handler
+	}
+}
+
+// ReferralHandler sets CallbackDispatcher's referralHandler to handler
+func ReferralHandler(handler MessageEntryHandler) HandlerSetter {
+	return func(dispatcher *CallbackDispatcher) {
+		dispatcher.referralHandler = handler
+	}
+}
+
+/*
+NewCallbackDispatcher creates a new callback dispatcher.
+*/
+func NewCallbackDispatcher(setters ...HandlerSetter) *CallbackDispatcher {
+	cb := &CallbackDispatcher{nullHandler, nullHandler, nullHandler, nullHandler, nullHandler}
+	for _, setter := range setters {
+		setter(cb)
+	}
+	return cb
 }
 
 /*
 Dispatch routes each MessagingEntry included in the callback to an appropriate
-handler for the type of entry.
+handler for the type of entry. It stops at the first handler that returns an error,
+skips the rest entries and returns the error as the final result.
 */
 func (dispatcher *CallbackDispatcher) Dispatch(cb *Callback) error {
 	for _, entry := range cb.Entries {
 		for _, messagingEntry := range entry.Messaging {
 			if messagingEntry.Message != nil {
-				if dispatcher.MessageHandler != nil {
-					dispatcher.MessageHandler(messagingEntry)
+				if err := dispatcher.messageHandler(messagingEntry); err != nil {
+					return err
 				}
 			} else if messagingEntry.Delivery != nil {
-				if dispatcher.DeliveryHandler != nil {
-					dispatcher.DeliveryHandler(messagingEntry)
+				if err := dispatcher.deliveryHandler(messagingEntry); err != nil {
+					return err
 				}
 			} else if messagingEntry.Postback != nil {
-				if dispatcher.PostbackHandler != nil {
-					dispatcher.PostbackHandler(messagingEntry)
+				if err := dispatcher.postbackHandler(messagingEntry); err != nil {
+					return err
 				}
 			} else if messagingEntry.OptIn != nil {
-				if dispatcher.AuthenticationHandler != nil {
-					dispatcher.AuthenticationHandler(messagingEntry)
+				if err := dispatcher.authenticationHandler(messagingEntry); err != nil {
+					return err
 				}
 			} else if messagingEntry.Referral != nil {
-				if dispatcher.ReferralHandler != nil {
-					dispatcher.ReferralHandler(messagingEntry)
+				if err := dispatcher.referralHandler(messagingEntry); err != nil {
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
Use null handler as default handler to remove handler checking when dispatching messages.

Make handlers private. Setup handlers through public functional options.